### PR TITLE
Enhancement/109 enhancement hierocreate autoset use review track

### DIFF
--- a/host/hiero/python/autoset_track_review.py
+++ b/host/hiero/python/autoset_track_review.py
@@ -14,12 +14,12 @@ def get_track_items():
     return track_items
 
 
-# Example usage
-track_items = get_track_items()
-for track_item in track_items:
-    track_name = track_item.parentTrack().name()
-    tags = track_item.tags()
-    for tag in tags:
-        metadata = tag.metadata()
-        if metadata.hasKey("reviewTrack"):
-            tag.metadata().setValue("tag.reviewTrack", track_name)
+def run():
+    track_items = get_track_items()
+    for track_item in track_items:
+        track_name = track_item.parentTrack().name()
+        tags = track_item.tags()
+        for tag in tags:
+            metadata = tag.metadata()
+            if metadata.hasKey("reviewTrack"):
+                tag.metadata().setValue("tag.reviewTrack", track_name)

--- a/host/hiero/python/autoset_track_review.py
+++ b/host/hiero/python/autoset_track_review.py
@@ -1,0 +1,25 @@
+import hiero.core
+
+
+def get_track_items():
+    # Get the active project
+    project = hiero.core.projects()[-1]  # Assuming the last project is the active one
+
+    # Get track items
+    track_items = []
+    for track in project.videoTracks():
+        for item in track.items():
+            track_items.append(item)
+
+    return track_items
+
+
+# Example usage
+track_items = get_track_items()
+for track_item in track_items:
+    track_name = track_item.parentTrack().name()
+    tags = track_item.tags()
+    for tag in tags:
+        metadata = tag.metadata()
+        if metadata.hasKey("reviewTrack"):
+            tag.metadata().setValue("tag.reviewTrack", track_name)


### PR DESCRIPTION
Custom Tool 'autoset_track_review.py' which allows the user to set the reviewTrack data on all track items 

# How to test
1. In, Openpype Launcher, Open 'Confo' Task, you can try with this one (TEST_OP2_PUB_23_7>Editorial>confo>Hiero Software
2. On the Bottom Panel ('Sequence'), you'll see the timeline with 2 Track Items, on each you can see the Openpype Logo, click on it and a tag window should open. In data part, you'll see the 'ReviewTrack' data is no set as expected(Should have the same name as the track where it is : 'edit')
3. Open "Script Editor" and execute this code : 
```
import hiero.core


def get_track_items():
    # Get the active project
    project = hiero.core.projects()[-1]  # Assuming the last project is the active one

    # Get track items
    track_items = []
    for track in project.videoTracks():
        for item in track.items():
            track_items.append(item)

    return track_items


def run():
    track_items = get_track_items()
    for track_item in track_items:
        track_name = track_item.parentTrack().name()
        tags = track_item.tags()
        for tag in tags:
            metadata = tag.metadata()
            if metadata.hasKey("reviewTrack"):
                tag.metadata().setValue("tag.reviewTrack", track_name)
```
 4. reviewTrack Data should be good now :) 