### PR TITLE
[NUKE] Fix AutoBackdrop issue

### DIFF
--- a/host/nuke/python/F_Backdrop.py
+++ b/host/nuke/python/F_Backdrop.py
@@ -116,11 +116,8 @@ def autoBackdrop():
     size.setRange(10, 100)
     space1 = nuke.Text_Knob('S01', ' ', ' ')
     space2 = nuke.Text_Knob('S02', ' ', ' ')
-    icon_path = os.path.join(
-        os.environ['QUAD_PLUGIN_PATH'],
-        "host/nuke/icons/AutoBackdrop/"
-    )
-
+    script_dir = os.path.dirname(os.path.dirname(__file__))
+    icon_path = os.path.join(script_dir,  'icons/AutoBackdrop')
     grow = nuke.PyScript_Knob(
         'grow',
         '<img src="{}/F_scalep.png">'.format(icon_path),


### PR DESCRIPTION
Simply replace an old QUAD_PLUGIN_PATH environment by a relative path in order to find the correct icons folder. This block the process of Backdrop creation in Nuke (Alt + B)

## HOW TO TEST

1. `git checkout bugfix/241-bug-op3169-quad100-nuke-autobackdrop-shortcut-doesnt-work ` in openpype-software-plugins repo (Clone it if not installed yet)
2. Overwrite the OPENPYPE_CUSTOM_SOFTWARE Variable in your local settings 
3. Open Nuke in a random context
4. Press Alt + B
5.  Should works now